### PR TITLE
Include `FetchInterceptor` in binding of setupServer (enable basic v18 native fetch support)

### DIFF
--- a/src/node/setupServer.ts
+++ b/src/node/setupServer.ts
@@ -1,4 +1,5 @@
 import { ClientRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/ClientRequest'
+import { FetchInterceptor } from '@mswjs/interceptors/lib/interceptors/fetch'
 import { XMLHttpRequestInterceptor } from '@mswjs/interceptors/lib/interceptors/XMLHttpRequest'
 import { createSetupServer } from './createSetupServer'
 
@@ -12,4 +13,5 @@ export const setupServer = createSetupServer(
   // so that MSW wouldn't bundle the unnecessary classes (i.e. "SocketPolyfill").
   ClientRequestInterceptor,
   XMLHttpRequestInterceptor,
+  FetchInterceptor,
 )


### PR DESCRIPTION
This is the minimal change to allow using native fetch in node v18. All it does is add another interceptor to `createServer`. This might not be desirable for package size changes, idk.

This does not depend on https://github.com/mswjs/interceptors/pull/283 but that will allow us to actually test in node v18 and also fix some specific scenarios that don't work out of the box (https I think).
